### PR TITLE
Sign Drop Claims with LockKeeper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+LOCK_KEEPER_URL=http://localhost:3000
+LOCK_KEEPER_TENANT=Game7
+LOCK_KEEPER_USERNAME=game7_service_provider
+LOCK_KEEPER_PASSWORD=password
+LOCK_KEEPER_POLICY=noop_policy

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ waggle_dev
 prod.env
 dev.env
 test.env
+.env

--- a/cmd.go
+++ b/cmd.go
@@ -144,7 +144,7 @@ func CreateSignCommand() *cobra.Command {
 	// All variables to be used for arguments.
 	var chainId int64
 	var batchSize int
-	var bugoutToken, cursorName, journalID, keyfile, password, claimant, dropperAddress, dropId, requestId, blockDeadline, amount, infile, outfile, query string
+	var bugoutToken, cursorName, journalID, keyfile, password, claimant, dropperAddress, dropId, requestId, blockDeadline, amount, infile, outfile, query, keyId string
 	var sensible, hashFlag, isCSV, header bool
 
 	signCommand.PersistentFlags().StringVarP(&keyfile, "keystore", "k", "", "Path to keystore file (this should be a JSON file).")
@@ -372,8 +372,6 @@ func CreateSignCommand() *cobra.Command {
 				return err
 			}
 
-			keyId := "2a13889e-250a-4195-9fbc-7522ce04e91f"
-
 			signedMessage, err := SignTypedMessage(messageData, keyId, accessToken)
 			if err != nil {
 				return err
@@ -392,11 +390,11 @@ func CreateSignCommand() *cobra.Command {
 			if encodeErr != nil {
 				return encodeErr
 			}
-			os.Stdout.Write([]byte("Test"))
 			os.Stdout.Write(resultJSON)
 			return nil
 		},
 	}
+	dropperSingleLkSubcommand.Flags().StringVar(&keyId, "key-id", "", "LockKeeper Key ID to use for signing.")
 	dropperSingleLkSubcommand.Flags().Int64Var(&chainId, "chain-id", 1, "Chain ID of the network you are signing for.")
 	dropperSingleLkSubcommand.Flags().StringVar(&dropperAddress, "dropper", "0x0000000000000000000000000000000000000000", "Address of Dropper contract")
 	dropperSingleLkSubcommand.Flags().StringVar(&dropId, "drop-id", "0", "ID of the drop.")
@@ -476,8 +474,6 @@ func CreateSignCommand() *cobra.Command {
 				return err
 			}
 
-			keyId := "2a13889e-250a-4195-9fbc-7522ce04e91f"
-
 			for _, message := range batch {
 				_, messageData, hashErr := DropperClaimMessageHash(chainId, dropperAddress, message.DropId, message.RequestID, message.Claimant, message.BlockDeadline, message.Amount)
 				if hashErr != nil {
@@ -507,6 +503,7 @@ func CreateSignCommand() *cobra.Command {
 			return nil
 		},
 	}
+	dropperBatchLkSubcommand.Flags().StringVar(&keyId, "key-id", "", "LockKeeper Key ID to use for signing.")
 	dropperBatchLkSubcommand.Flags().Int64Var(&chainId, "chain-id", 1, "Chain ID of the network you are signing for.")
 	dropperBatchLkSubcommand.Flags().StringVar(&dropperAddress, "dropper", "0x0000000000000000000000000000000000000000", "Address of Dropper contract")
 	dropperBatchLkSubcommand.Flags().StringVar(&infile, "infile", "", "Input file. If not specified, input will be expected from stdin.")

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.5 // indirect
 	github.com/aws/smithy-go v1.14.2 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	golang.org/x/text v0.13.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/lock_keeper.go
+++ b/lock_keeper.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
@@ -17,114 +17,121 @@ func Login() (string, error) {
 	//TODO: Move these to environment variables
 	lockKeeperURL := "http://localhost:3000"
 	tenantName := "Game7"
+	serviceProviderUsername := "game7_service_provider"
+	serviceProviderPassword := "password"
 
 	//TODO: Move these to environment variables
 	loginData := url.Values{
-		"username":   {"game7_service_provider"},
-		"password":   {"password"},
+		"username":   {serviceProviderUsername},
+		"password":   {serviceProviderPassword},
 		"grant_type": {"password"},
 	}
 
-	res, err := http.PostForm(
+	res, postErr := http.PostForm(
 		fmt.Sprintf("%s/%s/login", lockKeeperURL, tenantName),
 		loginData,
 	)
-	if err != nil {
-		os.Stdout.Write([]byte("Error making login request: " + err.Error() + "\n"))
-		return "", err
+	if postErr != nil {
+		return "", postErr
 	}
 	defer res.Body.Close()
 
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		os.Stdout.Write([]byte("Error reading login response body: " + err.Error() + "\n"))
-		return "", err
+	body, readErr := io.ReadAll(res.Body)
+	if readErr != nil {
+		return "", readErr
 	}
 
-	// Parse the JSON response to get the access token
 	var result map[string]interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		os.Stdout.Write([]byte("Error decoding login JSON response: " + err.Error() + "\n"))
-		return "", err
+	if deserializeErr := json.Unmarshal(body, &result); deserializeErr != nil {
+		return "", deserializeErr
 	}
 
 	accessToken := result["access_token"].(string)
-
 	return accessToken, nil
 }
 
 func SignTypedMessage(message apitypes.TypedData, keyId string, accessToken string) (string, error) {
-	lockKeeperURL := "http://localhost:3000" // replace with actual URL
+	// TODO: Move this to environment variable
+	lockKeeperURL := "http://localhost:3000"
+	policyName := "noop_policy"
 
-	// Encode message to JSON
-	jsonBytes, err := json.Marshal(message)
-	if err != nil {
-		os.Stdout.Write([]byte("Error encoding message to JSON: " + err.Error() + "\n"))
-		return "", err
+	jsonBytes, serializeErr := SerializeTypedDataWithoutSalt(message)
+	if serializeErr != nil {
+		return "", serializeErr
 	}
-
-	os.Stdout.Write(jsonBytes)
-
-	// Encode JSON to base64
 	typedData := base64.StdEncoding.EncodeToString(jsonBytes)
 
-	os.Stdout.Write([]byte(typedData))
-
-	// Prepare request body
 	reqBody := map[string]interface{}{
 		"typed_data":       typedData,
 		"authorizing_data": []interface{}{},
 		"key_id":           keyId,
-		"message_type":     "Erc2771",
-		"policies":         []string{"noop_policy"},
+		"message_type":     "Standard",
+		"policies":         []string{policyName},
 	}
 
-	// Encode request body to JSON
-	reqBodyJson, err := json.Marshal(reqBody)
-	if err != nil {
-		os.Stdout.Write([]byte("Error encoding request body to JSON: " + err.Error() + "\n"))
-		return "", err
+	reqBodyJson, serializeErr := json.Marshal(reqBody)
+	if serializeErr != nil {
+		return "", serializeErr
 	}
 
-	// Make the POST request
-	req, err := http.NewRequest("POST", lockKeeperURL+"/sign_message", bytes.NewBuffer(reqBodyJson))
-	if err != nil {
-		os.Stdout.Write([]byte("Error creating POST request: " + err.Error() + "\n"))
-		return "", err
+	req, reqErr := http.NewRequest("POST", lockKeeperURL+"/sign_message", bytes.NewBuffer(reqBodyJson))
+	if reqErr != nil {
+		return "", reqErr
 	}
-
-	// Set headers
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	// Send the request
 	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		os.Stdout.Write([]byte("Error making POST request: " + err.Error() + "\n"))
-		return "", err
+	resp, postErr := client.Do(req)
+	if postErr != nil {
+		return "", postErr
 	}
 	defer resp.Body.Close()
 
-	// Read the response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		os.Stdout.Write([]byte("Error reading response body: " + err.Error() + "\n"))
-		return "", err
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return "", readErr
 	}
 
-	// Print the body text
-	os.Stdout.Write(body)
-
-	// Parse the JSON response
 	var result map[string]interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		os.Stdout.Write([]byte("Error decoding JSON response: " + err.Error() + "\n"))
-		return "", err
+	if deserializeErr := json.Unmarshal(body, &result); deserializeErr != nil {
+		return "", deserializeErr
 	}
 
-	// Extract the signature from the response
 	signature := result["signature"].(string)
-
 	return signature, nil
+}
+
+// In order to sign the typed message with LockKeeper, we need to serialize
+// the typed data message without the salt field in the 'domain' object.
+type CustomDomain struct {
+	Name              string                `json:"name,omitempty"`
+	Version           string                `json:"version,omitempty"`
+	ChainId           *math.HexOrDecimal256 `json:"chainId,omitempty"`
+	VerifyingContract string                `json:"verifyingContract,omitempty"`
+}
+
+type CustomTypedData struct {
+	Types       map[string][]apitypes.Type `json:"types"`
+	PrimaryType string                     `json:"primaryType"`
+	Domain      CustomDomain               `json:"domain"`
+	Message     map[string]interface{}     `json:"message"`
+}
+
+func SerializeTypedDataWithoutSalt(original apitypes.TypedData) ([]byte, error) {
+	customDomain := CustomDomain{
+		Name:              original.Domain.Name,
+		Version:           original.Domain.Version,
+		ChainId:           original.Domain.ChainId,
+		VerifyingContract: original.Domain.VerifyingContract,
+	}
+
+	customTypedData := CustomTypedData{
+		Types:       original.Types,
+		PrimaryType: original.PrimaryType,
+		Domain:      customDomain,
+		Message:     original.Message,
+	}
+
+	return json.Marshal(customTypedData)
 }

--- a/lock_keeper.go
+++ b/lock_keeper.go
@@ -21,7 +21,6 @@ func Login() (string, error) {
 		return "", err
 	}
 
-	//TODO: Move these to environment variables
 	loginData := url.Values{
 		"username":   {lockKeeperConfig.Username},
 		"password":   {lockKeeperConfig.Password},
@@ -52,6 +51,10 @@ func Login() (string, error) {
 }
 
 func SignTypedMessage(message apitypes.TypedData, keyId string, accessToken string) (string, error) {
+	if keyId == "" {
+		return "", fmt.Errorf("lock keeper key-id is required")
+	}
+
 	lockKeeperConfig, err := LoadLockKeeperConfig()
 	if err != nil {
 		return "", err

--- a/lock_keeper.go
+++ b/lock_keeper.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+func Login() (string, error) {
+	//TODO: Move these to environment variables
+	lockKeeperURL := "http://localhost:3000"
+	tenantName := "Game7"
+
+	//TODO: Move these to environment variables
+	loginData := url.Values{
+		"username":   {"game7_service_provider"},
+		"password":   {"password"},
+		"grant_type": {"password"},
+	}
+
+	res, err := http.PostForm(
+		fmt.Sprintf("%s/%s/login", lockKeeperURL, tenantName),
+		loginData,
+	)
+	if err != nil {
+		os.Stdout.Write([]byte("Error making login request: " + err.Error() + "\n"))
+		return "", err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		os.Stdout.Write([]byte("Error reading login response body: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	// Parse the JSON response to get the access token
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		os.Stdout.Write([]byte("Error decoding login JSON response: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	accessToken := result["access_token"].(string)
+
+	return accessToken, nil
+}
+
+func SignTypedMessage(message apitypes.TypedData, keyId string, accessToken string) (string, error) {
+	lockKeeperURL := "http://localhost:3000" // replace with actual URL
+
+	// Encode message to JSON
+	jsonBytes, err := json.Marshal(message)
+	if err != nil {
+		os.Stdout.Write([]byte("Error encoding message to JSON: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	os.Stdout.Write(jsonBytes)
+
+	// Encode JSON to base64
+	typedData := base64.StdEncoding.EncodeToString(jsonBytes)
+
+	os.Stdout.Write([]byte(typedData))
+
+	// Prepare request body
+	reqBody := map[string]interface{}{
+		"typed_data":       typedData,
+		"authorizing_data": []interface{}{},
+		"key_id":           keyId,
+		"message_type":     "Erc2771",
+		"policies":         []string{"noop_policy"},
+	}
+
+	// Encode request body to JSON
+	reqBodyJson, err := json.Marshal(reqBody)
+	if err != nil {
+		os.Stdout.Write([]byte("Error encoding request body to JSON: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	// Make the POST request
+	req, err := http.NewRequest("POST", lockKeeperURL+"/sign_message", bytes.NewBuffer(reqBodyJson))
+	if err != nil {
+		os.Stdout.Write([]byte("Error creating POST request: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	// Set headers
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		os.Stdout.Write([]byte("Error making POST request: " + err.Error() + "\n"))
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		os.Stdout.Write([]byte("Error reading response body: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	// Print the body text
+	os.Stdout.Write(body)
+
+	// Parse the JSON response
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		os.Stdout.Write([]byte("Error decoding JSON response: " + err.Error() + "\n"))
+		return "", err
+	}
+
+	// Extract the signature from the response
+	signature := result["signature"].(string)
+
+	return signature, nil
+}

--- a/server.go
+++ b/server.go
@@ -471,7 +471,7 @@ func (server *Server) signDropperRoute(w http.ResponseWriter, r *http.Request, s
 	var callRequestSpecifications []CallRequestSpecification
 
 	for i, message := range req.Requests {
-		messageHash, hashErr := DropperClaimMessageHash(req.ChainId, req.Dropper, message.DropId, message.RequestID, message.Claimant, message.BlockDeadline, message.Amount)
+		messageHash, _, hashErr := DropperClaimMessageHash(req.ChainId, req.Dropper, message.DropId, message.RequestID, message.Claimant, message.BlockDeadline, message.Amount)
 		if hashErr != nil {
 			http.Error(w, "Unable to generate message hash", http.StatusInternalServerError)
 			return

--- a/sign.go
+++ b/sign.go
@@ -108,7 +108,7 @@ type DropperClaimMessage struct {
 	Signer        string `json:"signer,omitempty"`
 }
 
-func DropperClaimMessageHash(chainId int64, dropperAddress string, dropId, requestId string, claimant string, blockDeadline, amount string) ([]byte, error) {
+func DropperClaimMessageHash(chainId int64, dropperAddress string, dropId, requestId string, claimant string, blockDeadline, amount string) ([]byte, apitypes.TypedData, error) {
 	// Inspired by: https://medium.com/alpineintel/issuing-and-verifying-eip-712-challenges-with-go-32635ca78aaf
 	signerData := apitypes.TypedData{
 		Types: apitypes.Types{
@@ -143,5 +143,5 @@ func DropperClaimMessageHash(chainId int64, dropperAddress string, dropId, reque
 	}
 
 	messageHash, _, err := apitypes.TypedDataAndHash(signerData)
-	return messageHash, err
+	return messageHash, signerData, err
 }

--- a/sign_test.go
+++ b/sign_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDropperClaimMessageHash(t *testing.T) {
-	messageHash, err := DropperClaimMessageHash(80001, "0x4ec36E288E1b5d6914851a141cb041152Cf95328", "2", "5", "0x000000000000000000000000000000000000dEaD", "40000000", "3000000000000000000")
+	messageHash, _, err := DropperClaimMessageHash(80001, "0x4ec36E288E1b5d6914851a141cb041152Cf95328", "2", "5", "0x000000000000000000000000000000000000dEaD", "40000000", "3000000000000000000")
 	if err != nil {
 		t.Errorf("Unexpected error in DropperClaimMessageHash: %s", err.Error())
 	}


### PR DESCRIPTION
This PR adds the `LockKeeper` integration to the Waggle-CLI tool.

It introduces two new commands:
- `waggle sign dropper single-lk`
- `waggle sign dropper batch-lk`

Which works similar to their non `-lk` counterparts, but uses an external LockKeeper service to sign the requests, instead of relying in a local keystore file.

The main changes to these new commands is the new parameter called `key-id`, which expects a LockKeeper created key which will be used to sign the request.

This PR also introduces some required environment variables when using LockKeeper integrated commands:
- `LOCK_KEEPER_URL`: the URL where the tool will send requests to the LockKeeper service
- `LOCK_KEEPER_TENANT`: Which Tenant inside the LockKeeper service will be used
- `LOCK_KEEPER_USERNAME`: the username of the service provider user that will be used to sign requests
- `LOCK_KEEPER_PASSWORD`: the password of the service provider user that will be used to sign requests
- `LOCK_KEEPER_POLICY`: the name of the policy which will be used to approve sign requests, a noop policy is being used for this initial integration